### PR TITLE
Prepare 2.0.1 and automate GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Build, test and publish GitHub release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET SDK (from global.json)
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Check tag matches project version
+        shell: bash
+        run: |
+          project_version="$(dotnet msbuild Tiny.RestClient/Tiny.RestClient.csproj -nologo -getProperty:Version)"
+          tag_version="${GITHUB_REF_NAME#v}"
+
+          if [[ "$tag_version" != "$project_version" ]]; then
+            echo "Tag version '$tag_version' does not match project version '$project_version'."
+            exit 1
+          fi
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test --configuration Release --no-build --verbosity normal
+
+      - name: Pack
+        run: dotnet pack Tiny.RestClient/Tiny.RestClient.csproj --configuration Release --no-build --output artifacts
+
+      - name: Extract release notes
+        shell: bash
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+
+          awk -v version="$version" '
+            $0 == "# " version { found = 1; next }
+            found && /^# [^#]/ { exit }
+            found { print }
+            END { if (!found) exit 1 }
+          ' RELEASE-NOTES.md > release-notes.md
+
+          if [[ ! -s release-notes.md ]]; then
+            echo "No release notes found for version '$version'."
+            exit 1
+          fi
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create "$GITHUB_REF_NAME"
+          artifacts/*.nupkg
+          artifacts/*.snupkg
+          --verify-tag
+          --notes-file release-notes.md
+          --title "$GITHUB_REF_NAME"

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,14 +1,30 @@
 # Release notes
+
+# 2.0.1
+
+This maintenance release improves the release and distribution process. The public API and runtime behavior are unchanged from 2.0.0.
+
+## Release improvements
+
+* Add an automated GitHub release workflow triggered by version tags.
+* Verify that the Git tag matches the package version before publishing.
+* Build and test the complete solution before creating a release.
+* Attach the NuGet package (`.nupkg`) and symbol package (`.snupkg`) to the GitHub release.
+* Use the matching section of this file as the GitHub release description.
+
 # 2.0.0
-Major release. This version contains **breaking changes**, please read the migration notes below.
+
+Major release. This version contains **breaking changes**; please read the migration notes below.
 
 ## New features
-* **Server-Sent Events (SSE) streaming** : new `ExecuteAsSSEAsync` method which opens a streaming connection and yields each event (`ServerSentEvent`) as it is received. Available on **.NET Standard 2.1**, **.NET 8.0** and **.NET 10.0** (relies on `IAsyncEnumerable<T>`, not available on .NET Standard 2.0).
+
+* Add Server-Sent Events (SSE) streaming through `ExecuteAsSSEAsync`. The method opens a streaming connection and yields each `ServerSentEvent` as it is received.
+* SSE streaming is available on **.NET Standard 2.1**, **.NET 8.0**, and **.NET 10.0**. It relies on `IAsyncEnumerable<T>` and is therefore unavailable on .NET Standard 2.0.
 
 ```cs
-await foreach (var sse in client.
-                GetRequest("notifications/stream").
-                ExecuteAsSSEAsync(cancellationToken))
+await foreach (var sse in client
+    .GetRequest("notifications/stream")
+    .ExecuteAsSSEAsync(cancellationToken))
 {
     Console.WriteLine($"id    : {sse.Id}");
     Console.WriteLine($"event : {sse.Event}");
@@ -18,19 +34,23 @@ await foreach (var sse in client.
 ```
 
 ## Platform support
-* New target frameworks : **.NET Standard 2.0**, **.NET Standard 2.1**, **.NET 8.0** and **.NET 10.0**.
-* Legacy frameworks (.NET Framework 4.6.1 and older target frameworks) are no longer supported.
+
+* Target **.NET Standard 2.0**, **.NET Standard 2.1**, **.NET 8.0**, and **.NET 10.0**.
+* Remove support for .NET Framework 4.6.1 and other legacy target frameworks.
 
 ## Breaking changes
-* **Migration from Newtonsoft.Json to System.Text.Json** : the library no longer depends on Newtonsoft.Json. JSON serialization / deserialization is now handled by `System.Text.Json`. Custom `JsonSerializerSettings` / `JsonConverter` based on Newtonsoft are no longer supported.
-* **camelCase is now the default JSON formatting** (was PascalCase). If you rely on the previous behavior, restore it explicitly :
+
+* Replace Newtonsoft.Json with `System.Text.Json`. Newtonsoft-based `JsonSerializerSettings` and `JsonConverter` customizations are no longer supported.
+* Use camel case as the default JSON property naming policy instead of Pascal case. The previous behavior can be restored explicitly:
+
 ```cs
 client.Settings.Formatters.OfType<JsonFormatter>().First().UsePascalCase();
 ```
-* **`IFormatter` is now fully asynchronous.** If you implemented a custom formatter, you must update your implementation :
-  * `string Serialize<T>(T data, Encoding encoding)` becomes `Task<string> SerializeAsync<T>(T data, Encoding encoding, CancellationToken cancellationToken)`
-  * `T Deserialize<T>(Stream stream, Encoding encoding)` becomes `ValueTask<T> DeserializeAsync<T>(Stream stream, Encoding encoding, CancellationToken cancellationToken)`
-* Compression support has been removed.
+
+* Make `IFormatter` fully asynchronous. Custom formatter implementations must be updated:
+  * `string Serialize<T>(T data, Encoding encoding)` becomes `Task<string> SerializeAsync<T>(T data, Encoding encoding, CancellationToken cancellationToken)`.
+  * `T Deserialize<T>(Stream stream, Encoding encoding)` becomes `ValueTask<T> DeserializeAsync<T>(Stream stream, Encoding encoding, CancellationToken cancellationToken)`.
+* Remove compression support.
 
 # 1.7.1
 * Fixes for Blazor WASM

--- a/Tiny.RestClient/Tiny.RestClient.csproj
+++ b/Tiny.RestClient/Tiny.RestClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net10.0</TargetFrameworks>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
     <Copyright>Copyright © Jérôme Giacomini 2026</Copyright>
     <NeutralLanguage>en</NeutralLanguage>
     <Title>Tiny.RestClient</Title>


### PR DESCRIPTION
## Summary

- bump the package version to 2.0.1
- add a tag-triggered workflow that validates the version, builds, tests, packs, and creates the GitHub release
- attach the NuGet and symbol packages to the release
- add clean 2.0.1 release notes and improve the existing 2.0.0 notes

## Validation

- Release build succeeds with no warnings or errors
- 70 tests pass
- Tiny.RestClient.2.0.1.nupkg and Tiny.RestClient.2.0.1.snupkg are generated successfully

## Note

Publishing to NuGet.org is intentionally not included because it requires a repository secret containing the NuGet API key.